### PR TITLE
Fix well-known redirect URIs

### DIFF
--- a/server/dot-well-known-handlers/well-known.go
+++ b/server/dot-well-known-handlers/well-known.go
@@ -54,7 +54,7 @@ func (rt *WellKnownRouter) BlueskyClientMetadataHandler(w http.ResponseWriter, r
 		ClientID:                publicDomain + "/.well-known/bluesky-client-metadata.json",
 		ClientName:              appName,
 		ClientURI:               publicDomain,
-		RedirectURIs:            []string{"http://localhost:3000/oauth/callback", publicDomain + "/oauth/callback"},
+		RedirectURIs:            []string{"http://localhost:3000" + redirectURIPath, publicDomain + redirectURIPath},
 		GrantTypes:              []string{"authorization_code", "refresh_token"},
 		ResponseTypes:           []string{"code"},
 		Scope:                   "atproto",


### PR DESCRIPTION
## Summary
- correct redirect URIs in Bluesky client metadata

## Testing
- `GOTOOLCHAIN=local go test ./internal/... ./server/... ./components/...`

------
https://chatgpt.com/codex/tasks/task_e_6840b28238548331a954ca8f3f0cd875