### PR TITLE
fix: Fix toSnakeCase for consecutive capitals

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"unicode"
 
 	"github.com/creasty/defaults"
 	"github.com/go-playground/validator/v10"
@@ -122,10 +123,14 @@ func toSnakeCase(str string) string {
 	runes := []rune(str)
 	var out []rune
 	for i, r := range runes {
-		if i > 0 && r >= 'A' && r <= 'Z' {
-			out = append(out, '_')
+		if i > 0 && unicode.IsUpper(r) {
+			prev := runes[i-1]
+			nextLower := i+1 < len(runes) && unicode.IsLower(runes[i+1])
+			if !unicode.IsUpper(prev) || nextLower {
+				out = append(out, '_')
+			}
 		}
-		out = append(out, r)
+		out = append(out, unicode.ToLower(r))
 	}
-	return strings.ToLower(string(out))
+	return string(out)
 }

--- a/internal/config/snake_test.go
+++ b/internal/config/snake_test.go
@@ -1,0 +1,23 @@
+package config
+
+import "testing"
+
+func TestToSnakeCase(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"TestCamelCase", "test_camel_case"},
+		{"JWKSPrivate", "jwks_private"},
+		{"HTTPServerURL", "http_server_url"},
+		{"UserID", "user_id"},
+		{"API", "api"},
+	}
+
+	for _, c := range cases {
+		got := toSnakeCase(c.in)
+		if got != c.want {
+			t.Errorf("toSnakeCase(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- adjust `toSnakeCase` so that runs of capital letters are treated as a single word
- add unit tests that cover normal and consecutive-capital inputs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840b81fca9c8331a17e5f13000867a4