### PR TITLE
fix: Remove unused embed import

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	_ "embed"
-
 	"github.com/jrschumacher/dis.quest/cmd"
 	"github.com/jrschumacher/dis.quest/internal/config"
 	"github.com/jrschumacher/dis.quest/internal/logger"


### PR DESCRIPTION
## Summary
- clean up `main.go` by deleting the `_ "embed"` import
- run `gofmt` to keep formatting tidy

## Testing
- `gofmt main.go | diff -u main.go -`

------
https://chatgpt.com/codex/tasks/task_e_6840c00bd5308331bf2336f40308dbc4