### PR TITLE
chore: Update CI workflow for Go 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: go.mod
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@latest
       - name: Build


### PR DESCRIPTION
## Summary
- use `go-version-file` in CI to set Go version from `go.mod`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840c03529688331b7cc9a1f08aa7d0b