### PR TITLE
Read OAuth settings from config

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -38,5 +38,11 @@ public_domain: http://localhost:3000
 # Human friendly name displayed in OAuth metadata and UI.
 app_name: dis.quest
 
+# OAuth client identifier served at /auth/client-metadata.json
+oauth_client_id: https://dis.quest/auth/client-metadata.json
+
+# Redirect URL for OAuth callbacks
+oauth_redirect_url: https://dis.quest/auth/callback
+
 # Logging verbosity. One of: DEBUG, INFO, WARN, ERROR.
 log_level: INFO

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"net/http"
 
+	"github.com/jrschumacher/dis.quest/internal/config"
 	"golang.org/x/oauth2"
 )
 
@@ -25,11 +26,11 @@ func GeneratePKCE() (codeVerifier, codeChallenge string, err error) {
 }
 
 // OAuth2 config for Bluesky/ATProto (new OAuth2 flow)
-func OAuth2Config(provider string) *oauth2.Config {
+func OAuth2Config(provider string, cfg *config.Config) *oauth2.Config {
 	return &oauth2.Config{
-		ClientID:     "https://dis.quest/auth/client-metadata.json", // TODO: Use env var or config
-		ClientSecret: "",                                            // Not required for public clients
-		RedirectURL:  "https://dis.quest/auth/callback",             // TODO: Use env var or config
+		ClientID:     cfg.OAuthClientID,
+		ClientSecret: "", // Not required for public clients
+		RedirectURL:  cfg.OAuthRedirectURL,
 		Scopes:       []string{"atproto", "transition:generic"},
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  provider + "/oauth/authorize",
@@ -112,7 +113,7 @@ func GetRefreshTokenCookie(r *http.Request) (string, error) {
 }
 
 // Exchange code for token
-func ExchangeCodeForToken(ctx context.Context, provider, code, codeVerifier string) (*oauth2.Token, error) {
-	conf := OAuth2Config(provider)
+func ExchangeCodeForToken(ctx context.Context, provider, code, codeVerifier string, cfg *config.Config) (*oauth2.Token, error) {
+	conf := OAuth2Config(provider, cfg)
 	return conf.Exchange(ctx, code, oauth2.SetAuthURLParam("code_verifier", codeVerifier))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,11 +25,13 @@ type Config struct {
 	PDSEndpoint string `mapstructure:"pds_endpoint" default:"http://localhost:4000"`
 
 	// Security settings
-	DatabaseURL  string `secret:"true" mapstructure:"database_url"`
-	JWKSPrivate  string `validate:"required" secret:"true" mapstructure:"jwks_private" validate:"required"`
-	JWKSPublic   string `mapstructure:"jwks_public" validate:"required"`
-	PublicDomain string `mapstructure:"public_domain" validate:"required"`
-	AppName      string `mapstructure:"app_name" validate:"required"`
+	DatabaseURL      string `secret:"true" mapstructure:"database_url"`
+	JWKSPrivate      string `validate:"required" secret:"true" mapstructure:"jwks_private" validate:"required"`
+	JWKSPublic       string `mapstructure:"jwks_public" validate:"required"`
+	PublicDomain     string `mapstructure:"public_domain" validate:"required"`
+	AppName          string `mapstructure:"app_name" validate:"required"`
+	OAuthClientID    string `mapstructure:"oauth_client_id" validate:"required"`
+	OAuthRedirectURL string `mapstructure:"oauth_redirect_url" validate:"required"`
 
 	// Logging
 	LogLevel string `default:"INFO" validate:"oneof=DEBUG INFO WARN ERROR"`

--- a/server/auth-handlers/auth.go
+++ b/server/auth-handlers/auth.go
@@ -129,7 +129,7 @@ func (rt *AuthRouter) RedirectHandler(w http.ResponseWriter, r *http.Request) {
 		HttpOnly: true,
 		Secure:   true,
 	})
-	conf := auth.OAuth2Config(provider)
+	conf := auth.OAuth2Config(provider, cfg)
 	url := conf.AuthCodeURL(state,
 		oauth2.SetAuthURLParam("code_challenge", codeChallenge),
 		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
@@ -175,8 +175,9 @@ func (rt *AuthRouter) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = dpopKey // TODO: Use for DPoP JWT in token exchange
+	cfg := rt.Router.Config
 	// token, err := auth.ExchangeCodeForTokenWithDPoP(ctx, provider, code, verCookie.Value, dpopKey)
-	token, err := auth.ExchangeCodeForToken(ctx, provider, code, verCookie.Value)
+	token, err := auth.ExchangeCodeForToken(ctx, provider, code, verCookie.Value, cfg)
 	if err != nil {
 		writeError(w, http.StatusUnauthorized, "Token exchange failed", "handle", handle, "error", err)
 		return
@@ -186,7 +187,6 @@ func (rt *AuthRouter) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 		refreshToken = token.RefreshToken
 	}
 	// Use config for secure flag
-	cfg := rt.Router.Config
 	auth.SetSessionCookieWithEnv(w, token.AccessToken, []string{refreshToken}, cfg.AppEnv == "development")
 	http.Redirect(w, r, "/discussion", http.StatusSeeOther)
 }

--- a/server/dot-well-known-handlers/well-known.go
+++ b/server/dot-well-known-handlers/well-known.go
@@ -116,7 +116,8 @@ func (rt *WellKnownRouter) RedirectHandler(w http.ResponseWriter, r *http.Reques
 
 	// Get OAuth2 config with correct redirect URI
 	provider := publicDomain // For Bluesky, provider is the PDS base URL
-	conf := auth.OAuth2Config(provider)
+	cfg := rt.Router.Config
+	conf := auth.OAuth2Config(provider, cfg)
 	conf.RedirectURL = redirectURI
 
 	// Generate auth URL with required parameters


### PR DESCRIPTION
## Summary
- add OAuth client config fields
- use config values when building OAuth2 config
- document OAuth options in the example config

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840c02963dc83319ff6a2a347904f0c