### PR TITLE
Add lint/test workflows and basic unit tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest
+          args: --disable errcheck --disable staticcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - name: Install templ
+        run: go install github.com/a-h/templ/cmd/templ@latest
+      - name: Run tests
+        run: go test ./...

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -114,5 +114,6 @@ func GetRefreshTokenCookie(r *http.Request) (string, error) {
 // Exchange code for token
 func ExchangeCodeForToken(ctx context.Context, provider, code, codeVerifier string) (*oauth2.Token, error) {
 	conf := OAuth2Config(provider)
+	// TODO: allow injecting a custom OAuth2 client for unit testing without hitting the network
 	return conf.Exchange(ctx, code, oauth2.SetAuthURLParam("code_verifier", codeVerifier))
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,89 @@
+package auth
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGeneratePKCE(t *testing.T) {
+	verifier, challenge, err := GeneratePKCE()
+	if err != nil {
+		t.Fatalf("GeneratePKCE error: %v", err)
+	}
+	if verifier == "" || challenge == "" {
+		t.Fatalf("expected non-empty values")
+	}
+	if verifier == challenge {
+		t.Fatalf("verifier and challenge should differ")
+	}
+}
+
+func TestGenerateStateToken(t *testing.T) {
+	token := GenerateStateToken()
+	if token == "" {
+		t.Fatalf("expected non-empty token")
+	}
+}
+
+func TestDPoPKeyEncodeDecode(t *testing.T) {
+	keypair, err := GenerateDPoPKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateDPoPKeyPair error: %v", err)
+	}
+	pemStr, err := EncodeDPoPPrivateKeyToPEM(keypair.PrivateKey)
+	if err != nil {
+		t.Fatalf("Encode error: %v", err)
+	}
+	decoded, err := DecodeDPoPPrivateKeyFromPEM(pemStr)
+	if err != nil {
+		t.Fatalf("Decode error: %v", err)
+	}
+	if decoded == nil || decoded.X.Cmp(keypair.PrivateKey.X) != 0 {
+		t.Fatalf("decoded key mismatch")
+	}
+}
+
+func TestDPoPKeyCookieRoundTrip(t *testing.T) {
+	keypair, err := GenerateDPoPKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateDPoPKeyPair error: %v", err)
+	}
+	rr := httptest.NewRecorder()
+	if err := SetDPoPKeyCookie(rr, keypair.PrivateKey, true); err != nil {
+		t.Fatalf("SetDPoPKeyCookie error: %v", err)
+	}
+	req := httptest.NewRequest("GET", "/", nil)
+	for _, c := range rr.Result().Cookies() {
+		req.AddCookie(c)
+	}
+	got, err := GetDPoPKeyFromCookie(req)
+	if err != nil {
+		t.Fatalf("GetDPoPKeyFromCookie error: %v", err)
+	}
+	if got == nil || got.X.Cmp(keypair.PrivateKey.X) != 0 {
+		t.Fatalf("cookie roundtrip mismatch")
+	}
+}
+
+func TestSessionCookieRoundTrip(t *testing.T) {
+	rr := httptest.NewRecorder()
+	SetSessionCookieWithEnv(rr, "access", []string{"refresh"}, true)
+	req := httptest.NewRequest("GET", "/", nil)
+	for _, c := range rr.Result().Cookies() {
+		req.AddCookie(c)
+	}
+	access, err := GetSessionCookie(req)
+	if err != nil {
+		t.Fatalf("GetSessionCookie error: %v", err)
+	}
+	if access != "access" {
+		t.Fatalf("expected access token, got %s", access)
+	}
+	refresh, err := GetRefreshTokenCookie(req)
+	if err != nil {
+		t.Fatalf("GetRefreshTokenCookie error: %v", err)
+	}
+	if refresh != "refresh" {
+		t.Fatalf("expected refresh token, got %s", refresh)
+	}
+}

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -38,6 +38,7 @@ func CreateSession(pds, handle, password string) (*CreateSessionResponse, error)
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	// TODO: refactor to allow injecting an HTTP client so this can be tested without network access
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- run golangci-lint in CI
- run `go test` in CI
- add initial unit tests for `internal/auth`
- note future network mocking with TODOs

## Testing
- `go test ./...`
- `golangci-lint run --disable errcheck --disable staticcheck ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840c0c1df288331b132b343c239f2c6