### PR TITLE
feat(topic): add selectedAnswer to lexicon and mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project is an experimental implementation of a secure, discussion-style mes
 - Custom lexicons under `quest.dis.*` and `quest.dis.sec.*`
 - Discussion topics, messages, participation tracking
 - Optional encrypted messaging using OpenTDF-style fields
+- Q&A support via `selectedAnswer` on topics
 - Targeting full PDS/AppView compatibility
 - Written in idiomatic Go
 
@@ -35,6 +36,7 @@ This project is intentionally limited in scope to prioritize core discussion fea
 - **Thread** — Replies to a top-level message, supporting conversational depth
 - **Emoji Reactions** — Non-verbal message responses (e.g., 👍 ❤️ 🔥)
 - **Upvotes** — Lightweight endorsement signal for a message or thread
+- **Q&A Topics** — Threads with an accepted answer (stored in `selectedAnswer`)
 - **Mentions (`@handle`)** — Notifies tagged users (planned)
 - **WebSocket subscriptions** — Realtime updates for followed discussions (planned)
 - **Attachments** — Encrypted media or files associated with a post
@@ -43,7 +45,6 @@ This project is intentionally limited in scope to prioritize core discussion fea
 ### 🚫 Out of Scope
 
 - **Polls** — Voting-based discussions
-- **Q&A Topics** — Threads with accepted answers
 - **Direct Messaging** — 1:1 or group chat support
 - **Private Threads** — Topics with per-message visibility restrictions
 - **Rich Text Editors** — Markdown/WYSIWYG formatting is deferred to the client layer

--- a/api/disquest/quest.dis.topic.json
+++ b/api/disquest/quest.dis.topic.json
@@ -10,6 +10,10 @@
           "format": "did",
           "type": "string"
         },
+        "selectedAnswer": {
+          "description": "Record ID of the accepted reply",
+          "type": "string"
+        },
         "summary": {
           "maxLength": 2048,
           "type": "string"
@@ -41,6 +45,6 @@
     ],
     "key": "topic"
   },
-  "revision": 1,
+  "revision": 2,
   "type": "record"
 }

--- a/internal/pds/pds.go
+++ b/internal/pds/pds.go
@@ -5,14 +5,16 @@ import "fmt"
 
 // Post represents a minimal post structure for testing.
 type Post struct {
-	ID      string
-	Content string
+	ID             string
+	Content        string
+	SelectedAnswer string
 }
 
 // Service defines the interface for PDS operations.
 type Service interface {
 	CreatePost(content string) (*Post, error)
 	GetPost(id string) (*Post, error)
+	SetSelectedAnswer(postID, answerID string) error
 }
 
 // MockService is an in-memory mock implementation of Service.
@@ -38,4 +40,13 @@ func (m *MockService) GetPost(id string) (*Post, error) {
 		return nil, nil
 	}
 	return post, nil
+}
+
+func (m *MockService) SetSelectedAnswer(postID, answerID string) error {
+	post, ok := m.posts[postID]
+	if !ok {
+		return fmt.Errorf("post %s not found", postID)
+	}
+	post.SelectedAnswer = answerID
+	return nil
 }

--- a/internal/pds/pds_test.go
+++ b/internal/pds/pds_test.go
@@ -20,4 +20,16 @@ func TestMockService(t *testing.T) {
 	if fetched == nil || fetched.Content != "hello world" {
 		t.Errorf("expected to fetch post with content 'hello world', got %+v", fetched)
 	}
+
+	// set and verify selected answer
+	if err := mock.SetSelectedAnswer(post.ID, "reply-1"); err != nil {
+		t.Fatalf("SetSelectedAnswer failed: %v", err)
+	}
+	fetched, err = mock.GetPost(post.ID)
+	if err != nil {
+		t.Fatalf("GetPost failed: %v", err)
+	}
+	if fetched.SelectedAnswer != "reply-1" {
+		t.Errorf("expected selected answer 'reply-1', got '%s'", fetched.SelectedAnswer)
+	}
 }

--- a/lexicons/quest.dis.topic.json
+++ b/lexicons/quest.dis.topic.json
@@ -1,22 +1,49 @@
 {
   "id": "quest.dis.topic",
-  "revision": 1,
+  "revision": 2,
   "description": "Unencrypted discussion thread/topic definition",
   "type": "record",
   "record": {
     "key": "topic",
-    "allow": ["com.atproto.repo.createRecord"]
+    "allow": [
+      "com.atproto.repo.createRecord"
+    ]
   },
   "defs": {
     "main": {
       "type": "object",
-      "required": ["title", "createdBy", "createdAt"],
+      "required": [
+        "title",
+        "createdBy",
+        "createdAt"
+      ],
       "properties": {
-        "title": { "type": "string", "maxLength": 256 },
-        "summary": { "type": "string", "maxLength": 2048 },
-        "tags": { "type": "array", "items": { "type": "string" } },
-        "createdBy": { "type": "string", "format": "did" },
-        "createdAt": { "type": "string", "format": "datetime" }
+        "title": {
+          "type": "string",
+          "maxLength": 256
+        },
+        "summary": {
+          "type": "string",
+          "maxLength": 2048
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "createdBy": {
+          "type": "string",
+          "format": "did"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "selectedAnswer": {
+          "type": "string",
+          "description": "Record ID of the accepted reply"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- support accepted answers via new `selectedAnswer` topic field
- regenerate API lexicons
- update PDS mock and tests for selected answer
- document Q&A topics in README

## Testing
- `go test ./...`
- `golangci-lint run` *(fails: errcheck, staticcheck, qf1008)*

------
https://chatgpt.com/codex/tasks/task_e_6840c311a7248331993c7ad323d2ce40